### PR TITLE
Debug output for CGNS files; gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Compiled files
+*.o
+sim/bluebottle
+
+# Output files
+*.cgns
+*.pvd
+*.pvtr
+*.vtr
+*.vtp

--- a/src/bluebottle.c
+++ b/src/bluebottle.c
@@ -439,6 +439,7 @@ int main(int argc, char *argv[]) {
       if(runrestart != 1) {
         #ifdef DDEBUG
           init_VTK_ghost();
+          cgns_grid_ghost();
         #else
           if(rec_paraview_dt > 0) {
             init_VTK();
@@ -548,13 +549,22 @@ int main(int argc, char *argv[]) {
           cuda_part_pull();
 
         #ifdef DDEBUG
-            printf("Writing ParaView file %d (t = %e)...",
-            rec_paraview_stepnum_out, ttime);
+            // Paraview
+            printf("Writing ParaView file %d (t = %e)...", 
+                    rec_paraview_stepnum_out, ttime);
             fflush(stdout);
             out_VTK_ghost();
             rec_paraview_stepnum_out++;
             printf("done.               \n");
             fflush(stdout);
+
+            // CGNS
+            printf("Writing flow field file t = %e...", ttime);
+            fflush(stdout);
+            cgns_grid_ghost();
+            cgns_flow_field_ghost(rec_flow_field_dt);
+            rec_flow_field_stepnum_out++;
+            printf("done.               \n");
         #else
           if(rec_flow_field_dt > 0) {
             printf("Writing flow field file t = %e...", ttime);
@@ -721,7 +731,11 @@ int main(int argc, char *argv[]) {
                   ttime);
                 fflush(stdout);
               #endif
-              cgns_flow_field(rec_flow_field_dt);
+              #ifdef DDEBUG
+                cgns_flow_field_ghost(rec_flow_field_dt);
+              #else
+                cgns_flow_field(rec_flow_field_dt);
+              #endif
               printf("  Writing flow field file t = %e...done.\n", ttime);
               fflush(stdout);
               rec_flow_field_ttime_out = rec_flow_field_ttime_out

--- a/src/recorder.h
+++ b/src/recorder.h
@@ -71,6 +71,18 @@ void cgns_turb_grid(void);
  ******
  */
 
+/****f* recorder/cgns_grid_ghost()
+ * NAME
+ *  cgns_grid_ghost()
+ * TYPE
+ */
+void cgns_grid_ghost(void);
+/*
+ * FUNCTION
+ *  Write the CGNS grid ghost output file.
+ ******
+ */
+
 /****f* recorder/cgns_flow_field()
  * NAME
  *  cgns_flow_field()
@@ -94,6 +106,20 @@ void cgns_turb_flow_field(real dtout);
 /*
  * FUNCTION
  *  Write the CGNS flow_field output file.
+ * ARGUMENTS
+ *  * dtout -- the output timestep size
+ ******
+ */
+
+/****f* recorder/cgns_flow_field_ghost()
+ * NAME
+ *  cgns_flow_field_ghost()
+ * TYPE
+ */
+void cgns_flow_field_ghost(real dtout);
+/*
+ * FUNCTION
+ *  Write the CGNS flow_field ghost output file.
  * ARGUMENTS
  *  * dtout -- the output timestep size
  ******


### PR DESCRIPTION
-- recorder.c: Added cgns_grid_ghost and cgns_flow_field ghost
---- Same idea as normal output, except they output the ghost cells as well
---- Normal cgns output uses four points to interpolate velocities; this uses two -- would need a one-sided interpolation scheme to use four points at the ghost cells
---- WARNING: This means it is less accurate! But DEBUG should not be used for production runs anyways
-- recorder.h: Added function declarations
-- bluebottle.c: Added calls to cgns_grid_ghost and cgns_flow_field during DEBUG output (i.e., the same places we had the debug VTK output)
-- .gitignore: compiled files (*.o, sim/bluebottle) and output files (cgns and any form of pvd/vtr/etc.)